### PR TITLE
add logic for requiring WEATHER_API in production env

### DIFF
--- a/server/apis/packages.js
+++ b/server/apis/packages.js
@@ -4,7 +4,12 @@
 let knex = require('../../db/db');
 let router = require('express').Router();
 let requestPromise = require('request-promise');
-let WEATHER_API = require('../../APIKEYS.js').WEATHER_API
+let WEATHER_API;
+if (process.env.NODE_ENV!=='production'){
+  WEATHER_API = require('../../APIKEYS.js').WEATHER_API
+} else{
+  WEATHER_API = process.env.WEATHER_API;
+}
 
 module.exports = router;
 


### PR DESCRIPTION
- add process env in heroku
- add logic to require weather api thru local file or process env
