### PR TITLE
new fb oauth

### DIFF
--- a/client/components/login.js
+++ b/client/components/login.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { FACEBOOK_API } from '../../APIKEYS'
+class login extends React.Component {
+	render(){
+		return (
+			<div>
+				Yo
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />WHayt
+				<a href={`http://www.facebook.com/dialog/oauth?client_id=${FACEBOOK_API.facebookAuth.clientID}&scope=email&response_type=token&redirect_uri=http://localhost:4000/Preferences`}>facebook</a>
+			</div>
+			)
+	}
+}
+
+
+export default login;

--- a/client/components/navBar.js
+++ b/client/components/navBar.js
@@ -29,7 +29,7 @@ class NavBar extends React.Component{
           </NavDropdown>
           <AirportDropdown / >
           <LinkContainer className="navbar-button" to={{pathname:'/Preferences'}}><NavItem eventKey={4} href="#">Preferences</NavItem></LinkContainer>
-          <LinkContainer className="navbar-button" to={{pathname:'/auth/facebook'}}><NavItem eventKey={2} href="#"><img src="/assets/images/facebookLoginBtn.png" /></NavItem></LinkContainer>
+          <LinkContainer className="navbar-button" to={{pathname:'/login'}}><NavItem eventKey={2} href="#"><img src="/assets/images/facebookLoginBtn.png" /></NavItem></LinkContainer>
         </Nav>
       </Navbar>
       {this.props.children}

--- a/client/components/userForm.js
+++ b/client/components/userForm.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Button, FormGroup, FormControl, ControlLabel, Checkbox} from 'react-bootstrap';
+import axios from 'axios';
 
 let UserForm = React.createClass ({
     getInitialState:function(){
@@ -15,7 +16,11 @@ let UserForm = React.createClass ({
     },
     submitForm:function(event){
       event.preventDefault();
-      console.log(this.state)
+      console.log(this.state);
+      axios.post('/user_prefs', this.state)
+        .then(function(response) {
+          console.log(response);
+        })
     },
     render:function(){
         return (

--- a/client/components/userForm.js
+++ b/client/components/userForm.js
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Button, FormGroup, FormControl, ControlLabel, Checkbox} from 'react-bootstrap';
 import axios from 'axios';
+import queryString from 'query-string';
 
 let UserForm = React.createClass ({
     getInitialState:function(){
@@ -16,8 +17,12 @@ let UserForm = React.createClass ({
     },
     submitForm:function(event){
       event.preventDefault();
-      console.log(this.state);
-      axios.post('/user_prefs', this.state)
+      let qs = queryString.parse(window.location.hash);
+      // console.log(this.state);
+      // console.log('line 22 access_token is',qs.access_token);
+      let body = Object.assign({}, this.state, {token:qs.access_token});
+
+      axios.post('/user_prefs', body)
         .then(function(response) {
           console.log(response);
         })

--- a/client/components/userForm.js
+++ b/client/components/userForm.js
@@ -24,7 +24,12 @@ let UserForm = React.createClass ({
 
       axios.post('/user_prefs', body)
         .then(function(response) {
-          console.log(response);
+          if (response.status===200){
+            localStorage.setItem('goodbyeyall.fb_id',response.data.fb_id)
+          }else{
+            //throw error here?
+          }
+
         })
     },
     render:function(){

--- a/client/components/userForm.js
+++ b/client/components/userForm.js
@@ -7,7 +7,10 @@ import {Button, FormGroup, FormControl, ControlLabel, Checkbox} from 'react-boot
 let UserForm = React.createClass ({
     getInitialState:function(){
       return {
-        'DFWA-sky':true
+        'DFWA-sky':false,
+        'HOUA-sky':false,
+        'Seven Wonders':false,
+        'Seven Natural Wonders':false
       }
     },
     submitForm:function(event){
@@ -27,7 +30,7 @@ let UserForm = React.createClass ({
                     <Checkbox checked={this.state['DFWA-sky']} onChange={()=>{this.setState({'DFWA-sky':!this.state['DFWA-sky']});}}>
                       Dallas/Fort Worth (DFW & DAL)
                     </Checkbox>
-                    <Checkbox unchecked readOnly>
+                    <Checkbox checked={this.state['HOUA-sky']} onChange={()=>{this.setState({'HOUA-sky':!this.state['HOUA-sky']});}}>
                       Houston (IAH & HOU)
                     </Checkbox>
                    <FormGroup>
@@ -35,10 +38,10 @@ let UserForm = React.createClass ({
                         Choose your preferred travel packages below:
                       </FormControl.Static>
                     </FormGroup>
-                    <Checkbox unchecked readOnly>
+                    <Checkbox checked={this.state['Seven Wonders']} onChange={()=>{this.setState({'Seven Wonders':!this.state['Seven Wonders']});}}>
                       Seven Wonders of the World
                     </Checkbox>
-                    <Checkbox unchecked readOnly>
+                    <Checkbox checked={this.state['Seven Natural Wonders']} onChange={()=>{this.setState({'Seven Natural Wonders':!this.state['Seven Natural Wonders']});}}>
                       Seven Natural Wonders of the World
                     </Checkbox>
 

--- a/client/components/userForm.js
+++ b/client/components/userForm.js
@@ -4,18 +4,27 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Button, FormGroup, FormControl, ControlLabel, Checkbox} from 'react-bootstrap';
 
-class UserForm extends React.Component {
-    render() {
+let UserForm = React.createClass ({
+    getInitialState:function(){
+      return {
+        'DFWA-sky':true
+      }
+    },
+    submitForm:function(event){
+      event.preventDefault();
+      console.log(this.state)
+    },
+    render:function(){
         return (
             <div>
-                <form className="user-form">
+                <form className="user-form" onSubmit={this.submitForm}>
                     <FormGroup>
                       <ControlLabel>Alert Preferences</ControlLabel>
                       <FormControl.Static>
                         Choose your preferred outbound airports below:
                       </FormControl.Static>
                     </FormGroup>
-                    <Checkbox unchecked readOnly>
+                    <Checkbox checked={this.state['DFWA-sky']} onChange={()=>{this.setState({'DFWA-sky':!this.state['DFWA-sky']});}}>
                       Dallas/Fort Worth (DFW & DAL)
                     </Checkbox>
                     <Checkbox unchecked readOnly>
@@ -41,6 +50,6 @@ class UserForm extends React.Component {
                    )
     }
 
-}
+})
 
 export default UserForm;

--- a/client/public/routes.js
+++ b/client/public/routes.js
@@ -10,7 +10,7 @@ import { Route, IndexRoute } from 'react-router'
 // import routes from '../routes'
 import CardBox from '../containers/cardBox'
 import UserForm from '../components/userForm'
-
+import login from '../components/login'
 
 class Test extends React.Component {
 	render(){
@@ -26,6 +26,6 @@ export default(
 					<Route path="/HowItWorks" component={MissionStatement} />
 					<Route path="/MeetTheDevs" component={MeetTheDevs} />
 					<Route path="/Preferences" component={UserForm} />
-					<Route path="/auth/facebook"/>
+					<Route path="/login" component={login} />
 				</Route>
 )

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "pg": "^5.0.0",
     "pooled-pg": "0.0.7",
     "promise-throttle": "^0.2.0",
+    "query-string": "^4.2.2",
     "react": "^15.1.0",
     "react-bootstrap": "^0.29.4",
     "react-dom": "^15.1.0",

--- a/server/apis/user_prefs.js
+++ b/server/apis/user_prefs.js
@@ -11,6 +11,12 @@ knex.insertUserPrefs = function(prefsObj) {
 
 router.post('/',function(req, res) {
 	console.log(req.body);
-
+	knex.insertUserPrefs(req.body)
+		.then(function(data){
+			console.log("line 16 after call knex.insertUserPrefs:", data)
+		})
+		.catch(function (err) {
+			console.log("error on line 19",err);
+		})
 })
 

--- a/server/apis/user_prefs.js
+++ b/server/apis/user_prefs.js
@@ -2,21 +2,40 @@
 
 let router = require('express').Router();
 let knex = require('../../db/db');
-
+let requestPromise = require('request-promise');
 module.exports = router
 
 knex.insertUserPrefs = function(prefsObj) {
 	return knex('users').insert(prefsObj);
 }
 
+
+
 router.post('/',function(req, res) {
 	console.log(req.body);
-	knex.insertUserPrefs(req.body)
-		.then(function(data){
-			console.log("line 16 after call knex.insertUserPrefs:", data)
-		})
-		.catch(function (err) {
-			console.log("error on line 19",err);
-		})
+	let prefsObj=Object.assign({}, req.body);
+	if (req.body.token){
+		requestPromise(`https://graph.facebook.com/me?fields=id,name,email,picture&access_token=${req.body.token}`)
+			.then((data)=>{
+				data = JSON.parse(data);
+				prefsObj.fb_id = data.id;
+				prefsObj.profile_name = data.name;
+				prefsObj.profile_email = data.email;
+				prefsObj.profile_photo = data.picture.data.url;
+				console.log('line 24 prefsObj before insert into db', prefsObj)
+				return prefsObj
+			})
+			.then(knex.insertUserPrefs)
+			.then(()=>{
+				res.send(prefsObj);
+			});
+	}
+	// knex.insertUserPrefs(req.body)
+	// 	.then(function(data){
+	// 		console.log("line 16 after call knex.insertUserPrefs:", data)
+	// 	})
+	// 	.catch(function (err) {
+	// 		console.log("error on line 19",err);
+	// 	})
 })
 

--- a/server/apis/user_prefs.js
+++ b/server/apis/user_prefs.js
@@ -1,0 +1,9 @@
+'use strict'
+
+let router = require('express').Router();
+
+module.exports = router
+
+router.post('/',function(req, res) {
+	console.log(req.body);
+})

--- a/server/apis/user_prefs.js
+++ b/server/apis/user_prefs.js
@@ -22,7 +22,7 @@ router.post('/',function(req, res) {
 				prefsObj.profile_name = data.name;
 				prefsObj.profile_email = data.email;
 				prefsObj.profile_photo = data.picture.data.url;
-				console.log('line 24 prefsObj before insert into db', prefsObj)
+				// console.log('line 24 prefsObj before insert into db', prefsObj)
 				return prefsObj
 			})
 			.then(knex.insertUserPrefs)

--- a/server/apis/user_prefs.js
+++ b/server/apis/user_prefs.js
@@ -1,9 +1,16 @@
 'use strict'
 
 let router = require('express').Router();
+let knex = require('../../db/db');
 
 module.exports = router
 
+knex.insertUserPrefs = function(prefsObj) {
+	return knex('users').insert(prefsObj);
+}
+
 router.post('/',function(req, res) {
 	console.log(req.body);
+
 })
+

--- a/server/app.js
+++ b/server/app.js
@@ -13,7 +13,8 @@ let cheapest_ever_api = require('./apis/cheapest_ever_api');
 let last_thirty_days_api = require('./apis/last_thirty_days_api');
 let book_now_quote_api = require('./apis/book_now_quote_api');
 let passport = require('passport');
-let session = require('express-session')
+let session = require('express-session');
+let user_prefs = require('./apis/user_prefs');
 
 let routes = express.Router();
 
@@ -29,6 +30,7 @@ routes.use('/packages', select_package);
 routes.use('/cheapest_ever_api', cheapest_ever_api);
 routes.use('/last_thirty_days_api', last_thirty_days_api);
 routes.use('/book_now_quote_api', book_now_quote_api);
+routes.use('/user_prefs', user_prefs);
 
 
 if(process.env.NODE_ENV === 'test'){


### PR DESCRIPTION
- using hard coded facebook callback url to auth user instead of passport
- clicking the fb button will redirect to /login which render the login component
- after logging, user will be redirected to /Preferences with Facebook access_token in url
- preferences form submit will post to API endpoint, and will fetch user info from Facebook Graph API for user info
- insert user info and user preferences in db and send back user object to frontend
- frontend will now store the facebook  id of user in local storage 
