### PR TITLE
filter out avg prices in the past

### DIFF
--- a/server/apis/avg_api.js
+++ b/server/apis/avg_api.js
@@ -23,6 +23,12 @@ router.get('/:originCity/:destCity', function(req, res){
 				date: date
 			}
 		}))
+		.then( (array) => {
+			let date = JSON.stringify(new Date());
+			let month = date.slice(6,8);
+			let year = date.slice(1,5)
+			return array.filter((price)=> price.date >= (year+'-'+month))
+		})
 		.then( (array) => res.send(array) )
 });
 


### PR DESCRIPTION
- filter out past date /avg_price API so d3 component won't display data point from the past
