### PR TITLE
cheapestRouteEver

### DIFF
--- a/worker/cheapestRouteEver.js
+++ b/worker/cheapestRouteEver.js
@@ -30,7 +30,6 @@ knex.insertCheapestRoute = function(obj){
 		}
 		else if (currentCheapest.length===1){
 			if(obj.cheapest_price <= currentCheapest[0].cheapest_price){
-				obj.created_at = knex.fn.now();
 				return knex('cheapest_route_ever').where('id','=',currentCheapest[0].id).update(obj)
 			}
 			else{


### PR DESCRIPTION
- no longer overwriting created_at timestamp in flight object before updating cheapest_route_ever table

cheapestRouteEver created_at will now reflect when the flight is fetched from skyscanner
